### PR TITLE
Dont use full paths to gtk dlls on linux

### DIFF
--- a/Gtk/atk-sharp.dll.config
+++ b/Gtk/atk-sharp.dll.config
@@ -6,6 +6,6 @@
 
   <dllmap os="linux" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
   <dllmap os="linux" dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
-  <dllmap os="linux" dll="glibsharpglue-2" target="/usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so"/>
-  <dllmap os="linux" dll="atksharpglue-2" target="/usr/lib/cli/atk-sharp-2.0/libatksharpglue-2.so"/>
+  <dllmap os="linux" dll="glibsharpglue-2" target="libglibsharpglue-2.so"/>
+  <dllmap os="linux" dll="atksharpglue-2" target="libatksharpglue-2.so"/>
 </configuration>

--- a/Gtk/gdk-sharp.dll.config
+++ b/Gtk/gdk-sharp.dll.config
@@ -10,6 +10,6 @@
   <dllmap os="linux" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
   <dllmap os="linux" dll="libgdk-win32-2.0-0.dll" target="libgdk-x11-2.0.so.0"/>
   <dllmap os="linux" dll="libgdk_pixbuf-2.0-0.dll" target="libgdk_pixbuf-2.0.so.0"/>
-  <dllmap os="linux" dll="gdksharpglue-2" target="/usr/lib/cli/gdk-sharp-2.0/libgdksharpglue-2.so"/>
-  <dllmap os="linux" dll="glibsharpglue-2" target="/usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so"/>
+  <dllmap os="linux" dll="gdksharpglue-2" target="libgdksharpglue-2.so"/>
+  <dllmap os="linux" dll="glibsharpglue-2" target="libglibsharpglue-2.so"/>
 </configuration>

--- a/Gtk/glade-sharp.dll.config
+++ b/Gtk/glade-sharp.dll.config
@@ -3,5 +3,5 @@
   <dllmap os="osx" dll="gladesharpglue-2" target="/Library/Frameworks/Mono.framework/Versions/Current/lib//libgladesharpglue-2.so"/>
 
   <dllmap os="linux" dll="libglade-2.0-0.dll" target="libglade-2.0.so.0"/>
-  <dllmap os="linux" dll="gladesharpglue-2" target="/usr/lib/cli/glade-sharp-2.0/libgladesharpglue-2.so"/>
+  <dllmap os="linux" dll="gladesharpglue-2" target="libgladesharpglue-2.so"/>
 </configuration>

--- a/Gtk/glib-sharp.dll.config
+++ b/Gtk/glib-sharp.dll.config
@@ -7,5 +7,5 @@
   <dllmap os="linux" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
   <dllmap os="linux" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
   <dllmap os="linux" dll="libgthread-2.0-0.dll" target="libgthread-2.0.so.0"/>
-  <dllmap os="linux" dll="glibsharpglue-2" target="/usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so"/>
+  <dllmap os="linux" dll="glibsharpglue-2" target="libglibsharpglue-2.so"/>
 </configuration>

--- a/Gtk/gtk-sharp.dll.config
+++ b/Gtk/gtk-sharp.dll.config
@@ -10,6 +10,6 @@
   <dllmap os="linux" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
   <dllmap os="linux" dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
   <dllmap os="linux" dll="libgtk-win32-2.0-0.dll" target="libgtk-x11-2.0.so.0"/>
-  <dllmap os="linux" dll="gtksharpglue-2" target="/usr/lib/cli/gtk-sharp-2.0/libgtksharpglue-2.so"/>
-  <dllmap os="linux" dll="glibsharpglue-2" target="/usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so"/>
+  <dllmap os="linux" dll="gtksharpglue-2" target="libgtksharpglue-2.so"/>
+  <dllmap os="linux" dll="glibsharpglue-2" target="libglibsharpglue-2.so"/>
 </configuration>

--- a/Gtk/pango-sharp.dll.config
+++ b/Gtk/pango-sharp.dll.config
@@ -10,6 +10,6 @@
   <dllmap os="linux" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
   <dllmap os="linux" dll="libpango-1.0-0.dll" target="libpango-1.0.so.0"/>
   <dllmap os="linux" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.so.0"/>
-  <dllmap os="linux" dll="pangosharpglue-2" target="/usr/lib/cli/pango-sharp-2.0/libpangosharpglue-2.so"/>
-  <dllmap os="linux" dll="glibsharpglue-2" target="/usr/lib/cli/glib-sharp-2.0/libglibsharpglue-2.so"/>
+  <dllmap os="linux" dll="pangosharpglue-2" target="libpangosharpglue-2.so"/>
+  <dllmap os="linux" dll="glibsharpglue-2" target="libglibsharpglue-2.so"/>
 </configuration>


### PR DESCRIPTION
To address https://github.com/Mono-Game/MonoGame.Dependencies/issues/39.

Not sure what kind of testing is required, I was able to run the pipeline tool successfully after this change and not prior.