### PR TITLE
Added most of the Gtk 3 OS X stuff

### DIFF
--- a/Gtk3/atk-sharp.dll.config
+++ b/Gtk3/atk-sharp.dll.config
@@ -1,4 +1,7 @@
 <configuration>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
+
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libatk-1.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libatk-1.0.0.dylib"/>
 </configuration>

--- a/Gtk3/gdk-sharp.dll.config
+++ b/Gtk3/gdk-sharp.dll.config
@@ -1,7 +1,13 @@
 <configuration>
-  <dllmap dll="libgio-2.0-0.dll" target="libgio-2.0.so.0"/>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libgdk-3-0.dll" target="libgdk-3.so.0"/>
-  <dllmap dll="libgdk_pixbuf-2.0-0.dll" target="libgdk_pixbuf-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgio-2.0-0.dll" target="libgio-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgdk-3-0.dll" target="libgdk-3.so.0"/>
+	<dllmap os="!windows,osx" dll="libgdk_pixbuf-2.0-0.dll" target="libgdk_pixbuf-2.0.so.0"/>
+
+	<dllmap os="osx" dll="libgio-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgio-2.0.dylib"/>
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgdk-3-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdk-quartz-3.0.0.dylib"/>
+	<dllmap os="osx" dll="libgdk_pixbuf-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdk_pixbuf-2.0.0.dylib"/>
 </configuration>

--- a/Gtk3/gio-sharp.dll.config
+++ b/Gtk3/gio-sharp.dll.config
@@ -1,6 +1,11 @@
 <configuration>
-  <dllmap dll="libgio-2.0-0.dll" target="libgio-2.0.so.0"/>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libgthread-2.0-0.dll" target="libgthread-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgio-2.0-0.dll" target="libgio-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgthread-2.0-0.dll" target="libgthread-2.0.so.0"/>
+
+	<dllmap os="osx" dll="libgio-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgio-2.0.dylib"/>
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgthread-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgthread-2.0.0.dylib"/>
 </configuration>

--- a/Gtk3/glib-sharp.dll.config
+++ b/Gtk3/glib-sharp.dll.config
@@ -1,5 +1,9 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libgthread-2.0-0.dll" target="libgthread-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgthread-2.0-0.dll" target="libgthread-2.0.so.0"/>
+
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgthread-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgthread-2.0.0.dylib"/>
 </configuration>

--- a/Gtk3/gtk-dotnet.dll.config
+++ b/Gtk3/gtk-dotnet.dll.config
@@ -1,3 +1,5 @@
 <configuration>
-  <dllmap dll="libgdk-3-0.dll" target="libgdk-3.so.0"/>
+	<dllmap os="!windows,osx" dll="libgdk-3-0.dll" target="libgdk-3.so.0"/>
+
+	<dllmap os="osx" dll="libgdk-3-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgdk-quartz-3.0.0.dylib"/>
 </configuration>

--- a/Gtk3/gtk-sharp.dll.config
+++ b/Gtk3/gtk-sharp.dll.config
@@ -1,6 +1,11 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
-  <dllmap dll="libgtk-3-0.dll" target="libgtk-3.so.0"/>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libatk-1.0-0.dll" target="libatk-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgtk-3-0.dll" target="libgtk-3.so.0"/>
+
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libatk-1.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libatk-1.0.0.dylib"/>
+	<dllmap os="osx" dll="libgtk-3-0.dll" target="???"/>
 </configuration>

--- a/Gtk3/pango-sharp.dll.config
+++ b/Gtk3/pango-sharp.dll.config
@@ -1,6 +1,11 @@
 <configuration>
-  <dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
-  <dllmap dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
-  <dllmap dll="libpango-1.0-0.dll" target="libpango-1.0.so.0"/>
-  <dllmap dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libgobject-2.0-0.dll" target="libgobject-2.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libpango-1.0-0.dll" target="libpango-1.0.so.0"/>
+	<dllmap os="!windows,osx" dll="libpangocairo-1.0-0.dll" target="libpangocairo-1.0.so.0"/>
+
+	<dllmap os="osx" dll="libglib-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libglib-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libgobject-2.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libgobject-2.0.0.dylib"/>
+	<dllmap os="osx" dll="libpango-1.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libpango-1.0.0.dylib"/>
+	<dllmap os="osx" dll="libpangocairo-1.0-0.dll" target="/Library/Frameworks/Mono.framework/Versions/Current/lib/libpangocairo-1.0.0.dylib"/>
 </configuration>


### PR DESCRIPTION
Added most of the Gtk 3 OS X stuff...

The only thing missing is libgtk-3-0.dll in Gtk3/gtk-sharp.dll.config, it doesn't come by default with Mono so someone needs to compile it and add it.

I saw that Xwt had it's in: https://github.com/mono/xwt/blob/master/Xwt.Gtk/Xwt.Gtk3.dll.config